### PR TITLE
Refactor map creation functions

### DIFF
--- a/R/fips-data.R
+++ b/R/fips-data.R
@@ -3,7 +3,7 @@
 #' @param regions The region breakdown for the map, can be one of
 #'   (\code{"states"}, \code{"state"}, \code{"counties"}, \code{"county"}).
 #'   The default is \code{"states"}.
-#' @param as_sf DEPRECATED. This parameter has no effect and will be removed in
+#' @param as_sf Defunct, this parameter no longer has any effect and will be removed in
 #'  the future.
 #'
 #' @return An data frame of FIPS codes of the desired \code{regions}.
@@ -20,10 +20,6 @@ fips_data <- function(
   as_sf = TRUE
 ) {
   regions <- match.arg(regions)
-
-  if (!missing("as_sf"))
-    warning("`as_sf` is deprecated and no longer has any effect, all data is
-            returned as an `sf` object.")
 
   map_data <- usmapdata::us_map(regions)
   sf::st_geometry(map_data) <- NULL

--- a/R/us-map.R
+++ b/R/us-map.R
@@ -14,7 +14,7 @@
 #'  same name. The regions listed in the \code{include} parameter are applied first and the
 #'  \code{exclude} regions are then removed from the resulting map. Any excluded regions
 #'  not present in the included regions will be ignored.
-#' @param as_sf DEPRECATED. This parameter has no effect and will be removed in
+#' @param as_sf Defunct, this parameter no longer has any effect and will be removed in
 #'  the future.
 #'
 #' @return An `sf` data frame of US map coordinates divided by the desired \code{regions}.
@@ -35,10 +35,6 @@ us_map <- function(
   as_sf = TRUE
 ) {
   regions <- match.arg(regions)
-
-  if (!missing("as_sf"))
-    warning("`as_sf` is deprecated and no longer has any effect, all data is
-            returned as an `sf` object.")
 
   if (regions == "state") regions <- "states"
   else if (regions == "county") regions <- "counties"
@@ -70,7 +66,7 @@ us_map <- function(
 #' @param regions The region breakdown for the map, can be one of
 #'   (\code{"states"}, \code{"counties"}, as specified by the internal file names.
 #'   The default is \code{"states"}.
-#' @param as_sf DEPRECATED. This parameter has no effect and will be removed in
+#' @param as_sf Defunct, this parameter no longer has any effect and will be removed in
 #'  the future.
 #'
 #' @return An `sf` data frame of state or county centroid labels and positions
@@ -82,10 +78,6 @@ centroid_labels <- function(
   as_sf = TRUE
 ) {
   regions <- match.arg(regions)
-
-  if (!missing("as_sf"))
-    warning("`as_sf` is deprecated and no longer has any effect, all data is
-            returned as an `sf` object.")
 
   sf::read_sf(
     system.file("extdata", paste0("us_", regions, "_centroids.gpkg"),

--- a/man/centroid_labels.Rd
+++ b/man/centroid_labels.Rd
@@ -11,7 +11,7 @@ centroid_labels(regions = c("states", "counties"), as_sf = TRUE)
 (\code{"states"}, \code{"counties"}, as specified by the internal file names.
 The default is \code{"states"}.}
 
-\item{as_sf}{DEPRECATED. This parameter has no effect and will be removed in
+\item{as_sf}{Defunct, this parameter no longer has any effect and will be removed in
 the future.}
 }
 \value{

--- a/man/create_us_map.Rd
+++ b/man/create_us_map.Rd
@@ -2,26 +2,52 @@
 % Please edit documentation in R/create-us-map.R
 \name{create_us_map}
 \alias{create_us_map}
+\alias{ea_crs}
 \alias{transform2D}
+\alias{transform_alaska}
+\alias{transform_hawaii}
 \alias{compute_centroids}
+\alias{alaska_bbox}
+\alias{hawaii_bbox}
 \title{Internal map creation tools}
 \usage{
 create_us_map(type = c("states", "counties"), input_file, output_file)
 
+ea_crs()
+
 transform2D(angle = 0, scale = 1)
 
+transform_alaska(alaska)
+
+transform_hawaii(hawaii)
+
 compute_centroids(polygons, iterations = 3, initial_width_step = 10)
+
+alaska_bbox()
+
+hawaii_bbox()
 }
 \description{
 \code{create_us_map()} creates the modified shapefiles used by the
 \link[usmap]{usmap} package.
 
+\code{ea_crs()} returns the US National Atlas Equal Area coordinate reference system
+(CRS) used by this package and \code{usmap}.
+
 \code{transform2D()} computes a two dimensional affine transformation matrix
 for the provided rotation angle and scale factor.
+
+\code{transform_alaska()} applies the appropriate transform for the Alaska polygons.
+
+\code{transform_hawaii()} applies the appropriate transform for the Hawaii polygons.
 
 \code{compute_centroids()} computes the modified centroids for each state or
 county polygon using a center-of-mass technique on the largest polygon in
 the region.
+
+\code{alaska_bbox()} returns the bounding box of Alaska pre-transformation.
+
+\code{hawaii_bbox()} returns the bounding box of Hawaii pre-transformation.
 }
 \note{
 Using these functions externally is not recommended since they make certain

--- a/man/fips_data.Rd
+++ b/man/fips_data.Rd
@@ -11,7 +11,7 @@ fips_data(regions = c("states", "state", "counties", "county"), as_sf = TRUE)
 (\code{"states"}, \code{"state"}, \code{"counties"}, \code{"county"}).
 The default is \code{"states"}.}
 
-\item{as_sf}{DEPRECATED. This parameter has no effect and will be removed in
+\item{as_sf}{Defunct, this parameter no longer has any effect and will be removed in
 the future.}
 }
 \value{

--- a/man/us_map.Rd
+++ b/man/us_map.Rd
@@ -29,7 +29,7 @@ same name. The regions listed in the \code{include} parameter are applied first 
 \code{exclude} regions are then removed from the resulting map. Any excluded regions
 not present in the included regions will be ignored.}
 
-\item{as_sf}{DEPRECATED. This parameter has no effect and will be removed in
+\item{as_sf}{Defunct, this parameter no longer has any effect and will be removed in
 the future.}
 }
 \value{

--- a/tests/testthat/test-fips-data.R
+++ b/tests/testthat/test-fips-data.R
@@ -39,7 +39,3 @@ test_that("county FIPS codes load correctly", {
   expect_equal(county_fips[[3144, "county"]], "Weston County")
   expect_equal(county_fips[[3144, "fips"]], "56045")
 })
-
-test_that("as_sf deprecation warning occurs", {
-  expect_warning(fips_data(as_sf = TRUE))
-})

--- a/tests/testthat/test-usmap.R
+++ b/tests/testthat/test-usmap.R
@@ -74,8 +74,3 @@ test_that("centroid labels are loaded", {
   expect_equal(length(centroid_labels("states")[[1]]), 51)
   expect_equal(length(centroid_labels("counties")[[1]]), 3144)
 })
-
-test_that("as_sf deprecation warning occurs", {
-  expect_warning(us_map(as_sf = TRUE))
-  expect_warning(centroid_labels(as_sf = TRUE))
-})


### PR DESCRIPTION
* Created `alaska_bbox()`, `hawaii_bbox()`, `alaska_transform()`, and `hawaii_transform()` internal functions.
  * These are intended to be used by `usmap::usmap_transform()` for consistency. 
* Removed `as_sf` deprecation warnings since this change is intended to be an implementation detail from the perspective of `usmap`.
  * i.e. warnings should not be seen by `usmap` users for decisions made within this package they have little control over 