### PR TITLE
Add version check to release workflow

### DIFF
--- a/.github/workflow-resources/release-version-check.sh
+++ b/.github/workflow-resources/release-version-check.sh
@@ -1,0 +1,7 @@
+# assumes $INPUT_VERSION is set to the selected release version
+CURRENT_VERSION=$(echo "$(cat DESCRIPTION)" | grep "Version:" | awk '{print $2}')
+
+if [ "$(printf '%s\n' "$INPUT_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" = "$INPUT_VERSION" ]; then
+    echo "::error title=Invalid version::Provided version number must be higher than the current version ($CURRENT_VERSION)."
+    exit 1
+fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,20 @@
 
 name: release
+run-name: Release ${{ github.event.repository.name }} ${{ inputs.version }}
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version number (e.g. 1.0.2)"
+        required: true
+        type: string
+  # When calling this workflow from another repo, ensure the following files are
+  # located in the local .github/workflow-resources directory:
+  #   • release-checklist.R
+  #   • release-pr-body.md
+  #   • release-version-check.sh
+  workflow_call:
     inputs:
       version:
         description: "Release version number (e.g. 1.0.2)"
@@ -16,6 +28,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Check version number
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: .github/workflow-resources/release-version-check.sh
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
@@ -46,7 +63,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "[unreleased]"
-          replace: "usmapdata ${{ inputs.version }}"
+          replace: "${{ github.event.repository.name }} ${{ inputs.version }}"
           include: "NEWS.md"
           regex: false
 

--- a/.github/workflows/update-map-data.yaml
+++ b/.github/workflows/update-map-data.yaml
@@ -1,5 +1,6 @@
 
 name: update-map-data
+run-name: Update map data
 
 on:
   schedule:


### PR DESCRIPTION
### Changes
* Added version check to `release.yaml` workflow

### Notes
* This workflow now has a `workflow_call` trigger which should allow `usmap` to call this directly.
* If this works, the workflow will only need to be updated in this repository and should apply to both `usmap` and `usmapdata`.

