### PR TITLE
Remove `as_sf` parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # [unreleased]
 
+### Removed
+* The `as_sf` parameter has been completely removed from `us_map()`, `centroid_labels()`, and `fips_data()`.
+  * It was no longer used by `usmap` nor did it have any effect if set.
+  * Any existing code that sets it can safely delete it from `usmapdata` function calls.
+
 # usmapdata 0.5.0
 Released Thursday, May 22, 2025.
 
@@ -45,7 +50,6 @@ Released Sunday, February 4, 2024.
 This update continues the `sf` migration by setting the `as_sf` parameter to default to the behavior of `TRUE`. This parameter no longer has any effect, as explained below. The next phase will involve updating `usmap` to no longer make use of this parameter, in which case it can be completely removed.
 
 ### Removed
-
 * The `as_sf` parameter is now deprecated and no longer has any effect.
   * As part of this removal, the default behavior for `us_map()`, `centroid_labels()`, and `fips_data()` is equivalent to `as_sf = TRUE` which is to return their data as an `sf` object (see `0.2.0` release notes for more details).
   * This parameter will be completely removed in a future version but continues to exist for compatibility reasons.

--- a/R/fips-data.R
+++ b/R/fips-data.R
@@ -13,7 +13,6 @@
 #' @export
 fips_data <- function(
   regions = c("states", "state", "counties", "county"),
-  as_sf = TRUE,
   data_year = NULL
 ) {
   regions <- match.arg(regions)

--- a/R/us-map.R
+++ b/R/us-map.R
@@ -14,8 +14,6 @@
 #'  same name. The regions listed in the \code{include} parameter are applied first and the
 #'  \code{exclude} regions are then removed from the resulting map. Any excluded regions
 #'  not present in the included regions will be ignored.
-#' @param as_sf Defunct, this parameter no longer has any effect and will be removed in
-#'  the future.
 #' @param data_year The year for which to obtain map data.
 #' If the value is \code{NULL}, the most recent year's data is used. If the
 #' provided year is not found from the available map data sets, the next most
@@ -41,7 +39,6 @@ us_map <- function(
   regions = c("states", "state", "counties", "county"),
   include = c(),
   exclude = c(),
-  as_sf = TRUE,
   data_year = NULL
 ) {
   regions <- match.arg(regions)
@@ -80,7 +77,6 @@ us_map <- function(
 #' @export
 centroid_labels <- function(
   regions = c("states", "state", "counties", "county"),
-  as_sf = TRUE,
   data_year = NULL
 ) {
   regions <- match.arg(regions)

--- a/man/centroid_labels.Rd
+++ b/man/centroid_labels.Rd
@@ -6,7 +6,6 @@
 \usage{
 centroid_labels(
   regions = c("states", "state", "counties", "county"),
-  as_sf = TRUE,
   data_year = NULL
 )
 }
@@ -14,9 +13,6 @@ centroid_labels(
 \item{regions}{The region breakdown for the map, can be one of
 (\code{"states"}, \code{"state"}, \code{"counties"}, \code{"county"}).
 The default is \code{"states"}.}
-
-\item{as_sf}{Defunct, this parameter no longer has any effect and will be removed in
-the future.}
 
 \item{data_year}{The year for which to obtain map data.
 If the value is \code{NULL}, the most recent year's data is used. If the

--- a/man/fips_data.Rd
+++ b/man/fips_data.Rd
@@ -6,7 +6,6 @@
 \usage{
 fips_data(
   regions = c("states", "state", "counties", "county"),
-  as_sf = TRUE,
   data_year = NULL
 )
 }
@@ -14,9 +13,6 @@ fips_data(
 \item{regions}{The region breakdown for the map, can be one of
 (\code{"states"}, \code{"state"}, \code{"counties"}, \code{"county"}).
 The default is \code{"states"}.}
-
-\item{as_sf}{Defunct, this parameter no longer has any effect and will be removed in
-the future.}
 
 \item{data_year}{The year for which to obtain map data.
 If the value is \code{NULL}, the most recent year's data is used. If the

--- a/man/us_map.Rd
+++ b/man/us_map.Rd
@@ -8,7 +8,6 @@ us_map(
   regions = c("states", "state", "counties", "county"),
   include = c(),
   exclude = c(),
-  as_sf = TRUE,
   data_year = NULL
 )
 }
@@ -29,9 +28,6 @@ For counties, the FIPS must be provided as there can be multiple counties with t
 same name. The regions listed in the \code{include} parameter are applied first and the
 \code{exclude} regions are then removed from the resulting map. Any excluded regions
 not present in the included regions will be ignored.}
-
-\item{as_sf}{Defunct, this parameter no longer has any effect and will be removed in
-the future.}
 
 \item{data_year}{The year for which to obtain map data.
 If the value is \code{NULL}, the most recent year's data is used. If the


### PR DESCRIPTION
### Changes
<!-- List the changes made by the pull request and rationale where applicable -->
* Removed `as_sf` parameter from `us_map()`, `centroid_labels()`, and `fips_data()`

### Notes
<!--
List any other related notes,
e.g. how to test the changes or any known issues
-->
* `as_sf` was deprecated (and made defunct) in `usmapdata 0.2.1` over one year ago.
* `usmap` no longer makes use of this parameter and it has not had any effect since.
* Any `usmapdata` function calls making use of this parameter can safely remove it.

<!-- Include the issue number here if applicable -->
resolves #47 
