### PR TITLE
Fix `tibble` dependency issue in `read_sf()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # [unreleased]
 
+* Change output of `us_map()` and `centroid_labels()` to data frame instead of tibble.
+  * If `tibble` format is required use `tibble:as_tibble()`.
+
 # usmapdata 0.5.0
 Released Thursday, May 22, 2025.
 

--- a/R/create-us-map.R
+++ b/R/create-us-map.R
@@ -60,7 +60,7 @@ create_us_map <- function(
   type <- match.arg(type)
 
   # import map file
-  us <- sf::read_sf(input_file)
+  us <- sf::read_sf(input_file, as_tibble = FALSE)
 
   # ea: US National Atlas Equal Area
   us_ea <- sf::st_transform(us, ea_crs())

--- a/R/us-map.R
+++ b/R/us-map.R
@@ -51,7 +51,7 @@ us_map <- function(
   map_year <- select_map_year(data_year)
   file_name <- paste0("us_", regions, ".gpkg")
   file_path <- system.file("extdata", map_year, file_name, package = "usmapdata")
-  df <- sf::read_sf(file_path)
+  df <- sf::read_sf(file_path, as_tibble = FALSE)
 
   if (length(include) > 0) {
     df <- df[df$full %in% include |
@@ -91,7 +91,7 @@ centroid_labels <- function(
   file_name <- paste0("us_", regions, "_centroids.gpkg")
   file_path <- system.file("extdata", map_year, file_name, package = "usmapdata")
 
-  sf::read_sf(file_path)
+  sf::read_sf(file_path, as_tibble = FALSE)
 }
 
 #' Years for which US map data is available


### PR DESCRIPTION
### Changes
<!-- List the changes made by the pull request and rationale where applicable -->
* Set `as_tibble = FALSE` in `create_us_map()`, `us_map()`, and `centroid_labels()`

### Notes
<!--
List any other related notes,
e.g. how to test the changes or any known issues
-->
* This change is due to `ggplot2` no longer importing `tibble` by default (now a Suggests).
* For the purposes of this package, reading the simple features data as a data frame is suitable. 
* Any package consumers that require tibbles can easily convert them using `tibble:as_tibble()`.

<!-- Include the issue number here if applicable -->
resolves https://github.com/pdil/usmap/issues/117
